### PR TITLE
[AR-6998] update launch files default values

### DIFF
--- a/pandar_pointcloud/launch/PandarSwift_points.launch
+++ b/pandar_pointcloud/launch/PandarSwift_points.launch
@@ -9,7 +9,7 @@
   <arg name="host_ip" default="" />
   <arg name="frame_id" default="PandarSwift" />
   <arg name="manager" default="$(arg frame_id)_nodelet_manager" />
-  <arg name="max_range" default="130.0" />
+  <arg name="max_range" default="500.0" />
   <arg name="firetime_file" default="$(find pandar_pointcloud)/params/QT128C2X_Firetimes.csv"/>
   <arg name="min_range" default="0.5" />
   <arg name="pcap" default="" />
@@ -19,7 +19,7 @@
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
   <arg name="start_angle" default="0.0" />
-  <arg name="publish_model" default="both_point_raw" />
+  <arg name="publish_model" default="points" />
   <arg name="namespace" default="hesai"/>
   <arg name="multicast_ip"  default=""/>
   <arg name="coordinate_correction_flag" default="false" />

--- a/pandar_pointcloud_at128/launch/PandarSwift_points.launch
+++ b/pandar_pointcloud_at128/launch/PandarSwift_points.launch
@@ -8,7 +8,7 @@
   <arg name="host_ip" default="" />
   <arg name="frame_id" default="PandarSwift_AT128" />
   <arg name="manager" default="$(arg frame_id)_nodelet_manager" />
-  <arg name="max_range" default="130.0" />
+  <arg name="max_range" default="500.0" />
   <arg name="min_range" default="0.5" />
   <arg name="pcap" default="" />
   <arg name="port" default="2368" />
@@ -17,7 +17,7 @@
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
   <arg name="start_angle" default="0.0" />
-  <arg name="publish_model" default="both_point_raw" />
+  <arg name="publish_model" default="points" />
   <arg name="view_mode" default="1" />
   <arg name="namespace" default="hesai"/>
   <arg name="multicast_ip"  default=""/>

--- a/pandar_pointcloud_at128/launch/PandarSwift_points.launch
+++ b/pandar_pointcloud_at128/launch/PandarSwift_points.launch
@@ -17,7 +17,7 @@
   <arg name="repeat_delay" default="0.0" />
   <arg name="rpm" default="600.0" />
   <arg name="start_angle" default="0.0" />
-  <arg name="publish_model" default="points" />
+  <arg name="publish_model" default="point" />
   <arg name="view_mode" default="1" />
   <arg name="namespace" default="hesai"/>
   <arg name="multicast_ip"  default=""/>


### PR DESCRIPTION
* update default parameters for launch files
    * use higher max_range value as OT128 can see far beyond 130m (needs still to be verified)
    * update publish_model to only publish points and save resources